### PR TITLE
Chooses 0th album image

### DIFF
--- a/src/components/TrackInfoModal.js
+++ b/src/components/TrackInfoModal.js
@@ -81,10 +81,10 @@ export default class TrackInfoModal extends Component {
                 align="center"
               >
                 <FadeImage
-                  src={ selectedTrack.album.images[1].url }
+                  src={ selectedTrack.album.images[0].url }
                   style={{
-                    width: selectedTrack.album.images[1].width,
-                    height: selectedTrack.album.images[1].height,
+                    width: selectedTrack.album.images[0].width,
+                    height: selectedTrack.album.images[0].height,
                     marginRight: '16px',
                     marginTop: '16px',
                   }}

--- a/src/mosaic/MosaicPage.js
+++ b/src/mosaic/MosaicPage.js
@@ -27,10 +27,18 @@ class MosaicPage extends Component {
 
   render() {
     const { isFetching, tracks, error } = this.props;
-    const albumArtTiles = tracks.map(t => ({
-      url: `${t.album.images[1].url}?${new Date().getTime()}`,
+    const albumArtTiles = tracks.map(t => {
+      let url = "";
+      try{
+        url = `${t.album.images[0].url}?${new Date().getTime()}`;
+      } catch (e) {
+        console.log('Image did not exist, using blank href');
+      }
+      return {
+      url: url,
       onClickHandler: () => this.handleTileClick(t.id),
-    }));
+      }
+    });
 
     return (
       isFetching ?

--- a/src/recommended/RecommendedPage.js
+++ b/src/recommended/RecommendedPage.js
@@ -150,7 +150,7 @@ class RecommendedPage extends Component {
                     onClick={() => this.handleTrackClick(t.id)}
                   >
                     <FadeImage
-                      src={t.album.images[1].url}
+                      src={t.album.images[0].url}
                       style={{
                         minWidth: '150px',
                         maxWidth: '150px',


### PR DESCRIPTION
Fixes #1

The 0th image is more likely to exist on albums than the 1st is, so choose that.

Further work:
- handle the case where no images exist by providing a placeholder image
- make sure I haven't broken anything in the artists page, the images didn't link anywhere and were irregular sizes

Awesome work on this project, please ping me when you've taken a look at that further work and I'll share it with my colleagues at Spotify. Well done!
